### PR TITLE
スナップショット上のターミナル出力の折返しが画面の表示と一致しない問題を解決

### DIFF
--- a/core/src/console/consoleViewController.ts
+++ b/core/src/console/consoleViewController.ts
@@ -88,7 +88,6 @@ export class ConsoleViewController extends vscode.Disposable {
             const termBufferDetermined = event.termBufferDetermined;
             this.logStorage.update(termBufferDetermined.snippetId, (data) => {
                 data.output = termBufferDetermined.bufferData;
-                data.outputHtml = termBufferDetermined.html;
                 return data;
             });
             this.logStorage.write();
@@ -233,7 +232,7 @@ export class ConsoleViewController extends vscode.Disposable {
         const css = fs.readFile(cssUri.fsPath);
         const scriptUri = vscode.Uri.file(path.join(this.context.extensionPath, 'dist', 'snapshot', 'snapshot.js'));
         const script = fs.readFile(scriptUri.fsPath);
-        const renderingResult = await this.markdownEngine.renderSnapshot(tokens);
+        const renderingResult = await this.markdownEngine.renderSnapshot(tokens, event.snippetData);
         return `
         <!DOCTYPE html>
         <html style="${HtmlUtil.escapeHtml(event.style)}">

--- a/core/src/markdown/markdownEngineEnv.ts
+++ b/core/src/markdown/markdownEngineEnv.ts
@@ -1,5 +1,6 @@
 import { UiState } from '@ui/state/uiState';
 import { LogStorage } from '../storage/logStorage';
+import { SnippetData } from '@ui/model/consoleEvent';
 
 type RenderMode = 'webview' | 'snapshot';
 
@@ -9,5 +10,22 @@ export class MarkdownEngineEnv {
         public readonly state: UiState,
         public readonly logStorage: LogStorage,
         public readonly renderMode: RenderMode,
+        public readonly snippetOutputHtmls: Map<string, string>,
     ) {}
+}
+
+export class MarkdownEngineEnvBuilder {
+
+    public constructor(
+        public readonly state: UiState,
+        public readonly logStorage: LogStorage,
+        public readonly renderMode: RenderMode,
+    ) {}
+
+    public build(snippets: SnippetData[] = []): MarkdownEngineEnv {
+        const htmls = snippets ? snippets.map(snippet => {
+            return [snippet.id, snippet.outputHtml] as [string, string];
+        }) : [];
+        return new MarkdownEngineEnv(this.state, this.logStorage, this.renderMode, new Map(htmls));
+    }
 }

--- a/core/src/markdown/plugin/markdownItSnippet.tsx
+++ b/core/src/markdown/plugin/markdownItSnippet.tsx
@@ -17,11 +17,12 @@ export function markdownItSnippet() {
             const attr = MarkdownEngine.tryExtractSnippetAttribute(token);
             if (attr && attr.success) {
                 const maybeLog = attr.success ? env.logStorage.data.get(attr.success.id) : undefined;
+                const maybeOutputHtml = env.snippetOutputHtmls.get(attr.success.id);
                 const model: SnippetModel = {
                     attr: attr,
                     data: maybeLog ? {
                         output: maybeLog.output,
-                        outputHtml: maybeLog.outputHtml,
+                        outputHtml: maybeOutputHtml ? maybeOutputHtml : '',
                         startDateTime: maybeLog.start.toISOString(),
                         endDateTime: maybeLog.end.toISOString(),
                         exitCode: maybeLog.exitCode,

--- a/core/src/storage/logJsonAdapter.ts
+++ b/core/src/storage/logJsonAdapter.ts
@@ -10,7 +10,6 @@ export type LogEntry = {
     start: Date,
     end: Date,
     output: string,
-    outputHtml: string,
     exitCode: number,
 };
 
@@ -20,7 +19,6 @@ export type LogRawEntry = {
     start: string,
     end: string,
     output: string,
-    outputHtml: string,
     exitCode: number,
 };
 
@@ -59,7 +57,6 @@ export class LogJsonAdapter implements Adapter<LogSchema> {
             start: logEntry.start.toISOString(),
             end: logEntry.end.toISOString(),
             output: logEntry.output,
-            outputHtml: logEntry.outputHtml,
             exitCode: logEntry.exitCode,
         };
     }
@@ -71,7 +68,6 @@ export class LogJsonAdapter implements Adapter<LogSchema> {
             start: new Date(logRawEntry.start),
             end: new Date(logRawEntry.end),
             output: logRawEntry.output,
-            outputHtml: logRawEntry.outputHtml,
             exitCode: logRawEntry.exitCode,
         };
     }

--- a/core/src/storage/logStorage.ts
+++ b/core/src/storage/logStorage.ts
@@ -40,7 +40,6 @@ export class LogStorage {
                     start: new Date(0),
                     end: new Date(0),
                     output: '',
-                    outputHtml: '',
                     exitCode: -1,
                 };
                 this.db.data.set(snippetId, handler(entry));

--- a/ui/src/components/menu.tsx
+++ b/ui/src/components/menu.tsx
@@ -23,6 +23,7 @@ export function Menu({ vscodeApi, state }: Props) {
             saveSnapshotClicked: {
                 style: style ? style : '',
                 bodyClassList: Array.from(document.body.classList),
+                snippetData: state.extractSnippetData(),
             },
         };
         vscodeApi.postMessage(event);

--- a/ui/src/components/term.tsx
+++ b/ui/src/components/term.tsx
@@ -86,7 +86,7 @@ export const Term = memo(({state, attr}: Props) => {
     return (
         <div class="terminal-outer">
             {
-                state.webview && mode === 'runnable'
+                state.webview
                     ? (
                         <div class="terminal-root" ref={ref => newTerm(ref)}></div>
                     )

--- a/ui/src/components/term.tsx
+++ b/ui/src/components/term.tsx
@@ -59,6 +59,10 @@ export const Term = memo(({state, attr}: Props) => {
             } else {
                 term.open(ref);
             }
+            if (mode === 'preview') {
+                const hideCursorSequence = '\x1b[?25l';
+                term.write(hideCursorSequence);
+            }
             // trigger resizing term after 1 second after the last resizing
             let timerId: number | undefined = undefined;
             new ResizeObserver(() => {

--- a/ui/src/model/consoleEvent.ts
+++ b/ui/src/model/consoleEvent.ts
@@ -111,8 +111,6 @@ export type TermBufferDetermined = {
     snippetId: string,
 
     bufferData: string,
-
-    html: string,
 };
 
 export type SaveSnapshotClicked = {
@@ -120,6 +118,15 @@ export type SaveSnapshotClicked = {
     style: string,
 
     bodyClassList: string[],
+
+    snippetData: SnippetData[],
+};
+
+export type SnippetData = {
+
+    id: string,
+
+    outputHtml: string,
 };
 
 export type OpenLink = {

--- a/webview/src/webview.tsx
+++ b/webview/src/webview.tsx
@@ -163,19 +163,10 @@ window.addEventListener('load', () => {
             const snippetState = state.get(consoleEvent.processCompleted.snippetId);
             snippetState.markComplete(processCompleted.exitCode, new Date(processCompleted.endDateTime)).then(() => {
                 if (snippetState.webview) {
-                    // Remove trailing spaces of each line
-                    const trimRight = (html: string) => {
-                        // Remove <div>...</span>[[<span> </span>]]</div>,
-                        // keep <div><span> </span></div>
-                        return html
-                            .replaceAll(/ +(<\/span><\/div>)/g, ' $1')
-                            .replaceAll(/(<\/span>)<span> +<\/span>(<\/div>)/g, '$1$2');
-                    };
                     const event: ConsoleEvent = {
                         termBufferDetermined: {
                             snippetId: processCompleted.snippetId,
                             bufferData: snippetState.webview.serializeAddon.serialize(),
-                            html: trimRight(snippetState.webview.serializeAddon.serializeAsHTML({includeGlobalBackground: true})),
                         }
                     };
                     vscode.postMessage(event);


### PR DESCRIPTION
折返しが画面表示と一致しないのは以下のような経緯
- スナップショットに埋め込まれるターミナル出力の HTML はスニペットの実行完了時に保存される
- WebView の横幅に合わせてターミナル部分がリサイズされるが、保存された HTML にはリサイズが反映されない

以下のように修正して、画面表示の折返しがスナップショットでも再現されるようにする
- スナップショットに埋め込む HTML はスナップショットボタン押下時に抽出する
- HTML はファイルには保存しないようにする
- プレビューモードではターミナルの代わりにスナップショットと同じ HTML を表示する仕様になっていたが、出力のための HTML が保存されない仕様に変わるため、実行時と同様にターミナルを表示する