### PR TITLE
TOCアイテムに title を設定

### DIFF
--- a/ui/src/toc/toc.ts
+++ b/ui/src/toc/toc.ts
@@ -19,6 +19,17 @@ export function setupTocTo(window: Window, options: TocOptions) {
         throw new Error('invalid toc item');
     });
 
+    const setTocItemTitles = () => {
+        Array.from(document.querySelectorAll('nav.table-of-contents li a')).map(e => {
+            if (e instanceof HTMLAnchorElement) {
+                const title = e.textContent;
+                if (title) {
+                    e.setAttribute('title', title);
+                }
+            }
+        });
+    };
+
     const decorateTocItems = () => {
         const windowTop = options.topPaddingPx;
         const windowBottom = window.innerHeight - options.bottomPaddingPx;
@@ -40,6 +51,8 @@ export function setupTocTo(window: Window, options: TocOptions) {
             }
         });
     };
+
+    setTocItemTitles();
     decorateTocItems();
     new ResizeObserver(decorateTocItems).observe(document.body);
     window.addEventListener('resize', decorateTocItems);


### PR DESCRIPTION
TOC アイテムが長すぎて見切れていたときに、マウスオーバーで確認できるようにする